### PR TITLE
3.10 upgrade

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
       args:
         # [Choice] Python version: 3, 3.8, 3.7, 3.6
-        VARIANT: 3.9
+        VARIANT: "3.10"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000
         USER_GID: 1000

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Steps for running the server:
 2. Install the requirements:
 
     ```shell
-    pip install -r requirements.txt
+    python3 -m pip install -r requirements.txt
     ```
 
 3. Create an `.env` file using `.env.sample` as a guide. Set the value of `DBNAME` to the name of an existing database in your local PostgreSQL instance. Set the values of `DBHOST`, `DBUSER`, and `DBPASS` as appropriate for your local PostgreSQL instance. If you're in the devcontainer, copy the values from `.env.sample.devcontainer`.
@@ -42,13 +42,13 @@ Steps for running the server:
 4. Run the migrations:
 
     ```shell
-    flask db upgrade
+    python3 -m flask db upgrade
     ```
 
 5. Run the local server: (or use VS Code "Run" button and select "Run server")
 
     ```shell
-    flask run
+    python3 -m flask run
     ```
 
 ### Deployment

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -92,7 +92,7 @@ resource web 'Microsoft.Web/sites@2022-03-01' = {
     serverFarmId: appServicePlan.id
     siteConfig: {
       alwaysOn: true
-      linuxFxVersion: 'PYTHON|3.9'
+      linuxFxVersion: 'PYTHON|3.10'
       ftpsState: 'Disabled'
       appCommandLine: 'startup.sh'
     }


### PR DESCRIPTION
## Purpose

The [azure-docs-pr](https://github.com/MicrosoftDocs/azure-docs-pr/pull/226743) got merged, so it will soon recommend 3.10. This PR changes the repo to match the article, both in the Dev Container configuration and the Bicep App Service resource definition.

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

I tested opening in Codespaces with the new Dev Container configuration and running the app locally there. I then checked deployment still worked with the azd CLI (my CI build was successful), and that the deployed App Service app was up and running.
