### PR TITLE
Remove github-cli as Dev Container feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,6 @@
 	"service": "app",
 	"workspaceFolder": "/workspace",
 	"features": {
-		"ghcr.io/devcontainers/features/github-cli:1": {
-			"version": "latest"
-		}
 	},
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
The latest version of the azd CLI does not have a dependency on the github-cli, as it pulls it in itself when needed (for azd pipeline config). This change will make the Dev Container / Codespace faster to load, since features definitely add to load time.

I'll make same PR for Flask repo.