### PR TITLE
Azure Managed Redis updates

### DIFF
--- a/.env
+++ b/.env
@@ -3,4 +3,4 @@ DBNAME=app
 DBHOST=localhost
 DBUSER=app_user
 DBPASS=app_password
-CACHELOCATION=redis://redis:6379/0
+CACHELOCATION=redis://redis:10000/0

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ description: This is a Python web app using the Flask framework and the Azure Da
 
 # Deploy a Python (Flask) web app with PostgreSQL in Azure
 
-This is a Python web app using the Flask framework and the Azure Database for PostgreSQL relational database service. The Flask app is hosted in a fully managed Azure App Service. This app is designed to be be run locally and then deployed to Azure. You can either deploy this project by following the tutorial [*Deploy a Python (Django or Flask) web app with PostgreSQL in Azure*](https://docs.microsoft.com/azure/app-service/tutorial-python-postgresql-app) or by using the [Azure Developer CLI (azd)](https://learn.microsoft.com/azure/developer/azure-developer-cli/overview) according to the instructions below.
+This is a Python web app using the Flask framework and the Azure Database for PostgreSQL relational database service. The Flask app is hosted in a fully managed Azure App Service. This app is designed to be be run locally and then deployed to Azure. You can either deploy this project by following the tutorial [*Deploy a Python (Django or Flask) web app with PostgreSQL in Azure*](https://docs.microsoft.com/azure/app-service/tutorial-python-postgresql-app) or by using the [Azure Developer CLI (azd)](https://learn.microsoft.com/azure/developer/azure-developer-cli/overview) according to the instructions below. The Azure deployment includes Azure Managed Redis for Redis-compatible caching scenarios.
 
 ## Requirements
 

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -148,7 +148,7 @@ resource privateDnsZoneDB 'Microsoft.Network/privateDnsZones@2024-06-01' = {
   }  
 }
 
-// Resources needed to secure Redis Cache behind a private endpoint
+// Resources needed to secure Azure Managed Redis behind a private endpoint
 resource cachePrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-03-01' = {
   name: '${appName}-cache-privateEndpoint'
   location: location
@@ -161,7 +161,7 @@ resource cachePrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-03-01' = 
         name: '${appName}-cache-privateEndpoint'
         properties: {
           privateLinkServiceId: redisCache.id
-          groupIds: ['redisCache']
+          groupIds: ['redisEnterprise']
         }
       }
     ]
@@ -181,7 +181,7 @@ resource cachePrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-03-01' = 
   }
 }
 resource privateDnsZoneCache 'Microsoft.Network/privateDnsZones@2024-06-01' = {
-  name: 'privatelink.redis.cache.windows.net'
+  name: 'privatelink.redis.azure.net'
   location: 'global'
   dependsOn: [
     virtualNetwork
@@ -274,21 +274,23 @@ resource dbserver 'Microsoft.DBforPostgreSQL/flexibleServers@2022-01-20-preview'
   ]
 }
 
-// The Redis cache is configured to the minimum pricing tier
-resource redisCache 'Microsoft.Cache/redis@2024-11-01' = {
+// Azure Managed Redis is configured to the minimum pricing tier
+resource redisCache 'Microsoft.Cache/redisEnterprise@2026-05-01-preview' = {
   name: '${appName}-cache'
   location: location
+  sku: {
+    name: 'Balanced_B0'
+  }
   properties: {
-    sku: {
-      name: 'Basic'
-      family: 'C'
-      capacity: 0
-    }
-    redisConfiguration: {}
-    enableNonSslPort: false
-    redisVersion: '6'
+    encryption: {}
+    minimumTlsVersion: '1.2'
     publicNetworkAccess: 'Disabled'
   }
+}
+
+resource redisDatabase 'Microsoft.Cache/redisEnterprise/databases@2026-05-01-preview' existing = {
+  parent: redisCache
+  name: 'default'
 }
 
 // The App Service plan is configured to the B1 pricing tier
@@ -430,7 +432,7 @@ resource cacheConnector 'Microsoft.ServiceLinker/linkers@2024-04-01' = {
     clientType: 'python'
     targetService: {
       type: 'AzureResource'
-      id:  resourceId('Microsoft.Cache/Redis/Databases', redisCache.name, '0')
+      id: redisDatabase.id
     }
     authInfo: {
       authType: 'accessKey'


### PR DESCRIPTION
Updated [resources.bicep](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use Azure Managed Redis Enterprise conventions.
Changed private endpoint group ID to redisEnterprise.
Updated Redis private DNS zone to privatelink.redis.azure.net.
Added encryption block on Redis Enterprise resource.
Updated Service Linker target to the Redis database resource ID.
Updated README wording to remove legacy Redis Cache phrasing.